### PR TITLE
Expose `artist.documents({ partner: str, artist: str })`

### DIFF
--- a/endpoints/artist.js
+++ b/endpoints/artist.js
@@ -183,6 +183,26 @@ Artist.prototype.auctionLots = function (args) {
 };
 
 /**
+ * Get partner documents for a partner artist by ID
+ *
+ * @param {Object} options { partner: str, artist: str }
+ * @param {Object} options Optional options.
+ * @param {function} fn The callback.
+ * @returns {Assign}
+ * @api public
+ */
+Artist.prototype.documents = function (args) {
+  args = this.api.args(arguments);
+
+  var options = args.options || {};
+  return this.send(
+    ['partner', options.partner, 'artist', options.artist, 'documents'],
+    options,
+    args.fn
+  );
+};
+
+/**
  * Return an artists genome
  *
  * @param {String} str Artists name

--- a/endpoints/show.js
+++ b/endpoints/show.js
@@ -16,6 +16,7 @@ function Show (api) {
  * Get a partner show by ID
  *
  * @param {String} str show id
+ * @param {Object} options { partner: str, show: str }
  * @param {Object} options Optional options.
  * @param {function} fn The callback.
  * @returns {Assign}
@@ -46,7 +47,7 @@ Show.prototype.get = function (args) {
 /**
  * Get Artworks for a partner show by ID
  *
- * @param {String} str show id
+ * @param {Object} options { partner: str, show: str }
  * @param {Object} options Optional options.
  * @param {function} fn The callback.
  * @returns {Assign}
@@ -84,9 +85,9 @@ Show.prototype.images = function (args) {
 };
 
 /**
- * Get Installation images for a partner show by ID
+ * Get documents for a partner show by ID
  *
- * @param {String} str show id
+ * @param {Object} options { partner: str, show: str }
  * @param {Object} options Optional options.
  * @param {function} fn The callback.
  * @returns {Assign}

--- a/test/artist-test.js
+++ b/test/artist-test.js
@@ -24,6 +24,18 @@ vows.describe('artsy/artist').addBatch({
         //
         debug('artist.artworks', artworks);
       }
+    }),
+    'artist.documents': macros.call({
+      partner: 'aca-galleries',
+      artist: 'faith-ringgold'
+    }, {
+      'should return documents from the artist': function (documents) {
+        assert.isArray(documents);
+        //
+        // TODO (indexzero): More asserts.
+        //
+        debug('artist.documents', documents);
+      }
     })
     //
     // Remark (indexzero): these seem only accessible to Artsy admins


### PR DESCRIPTION
Adds support for artist "partner documents" via `artist.documents`.